### PR TITLE
Add option to throw error instead of setting body

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,9 +46,13 @@ function ratelimit(opts) {
     var remaining = limit.remaining > 0 ? limit.remaining - 1 : 0;
 
     // header fields
-    this.set('X-RateLimit-Limit', limit.total);
-    this.set('X-RateLimit-Remaining', remaining);
-    this.set('X-RateLimit-Reset', limit.reset);
+    var headers = {
+      'X-RateLimit-Limit': limit.total,
+      'X-RateLimit-Remaining': remaining,
+      'X-RateLimit-Reset': limit.reset
+    };
+
+    this.set(headers);
 
     debug('remaining %s/%s %s', remaining, limit.total, id);
     if (limit.remaining) return yield* next;
@@ -56,7 +60,12 @@ function ratelimit(opts) {
     var delta = (limit.reset * 1000) - Date.now() | 0;
     var after = limit.reset - (Date.now() / 1000) | 0;
     this.set('Retry-After', after);
+
     this.status = 429;
     this.body = 'Rate limit exceeded, retry in ' + ms(delta, { long: true });
+
+    if (opts.throw) {
+      this.throw(this.status, this.body, { headers: headers });
+    }
   }
 }

--- a/test/ratelimit.js
+++ b/test/ratelimit.js
@@ -71,6 +71,58 @@ describe('ratelimit middleware', function() {
     });
   });
 
+  describe('limit with throw', function() {
+    var guard;
+    var app;
+
+    var routeHitOnlyOnce = function() {
+      guard.should.be.equal(1);
+    };
+
+    beforeEach(function(done) {
+      app = koa();
+
+      app.use(function *(next) {
+        try {
+          yield* next;
+        } catch (e) {
+          this.body = e.message;
+          this.set(e.headers);
+        }
+      });
+
+      app.use(ratelimit({
+        duration: rateLimitDuration,
+        db: db,
+        max: 1,
+        throw: true
+      }));
+
+      app.use(function* (next) {
+        guard++;
+        this.body = goodBody + guard;
+      });
+
+      guard = 0;
+
+      setTimeout(function() {
+        request(app.listen())
+          .get('/')
+          .expect(200, goodBody + "1")
+          .expect(routeHitOnlyOnce)
+          .end(done);
+      }, rateLimitDuration);
+    });
+
+    it('responds with 429 when rate limit is exceeded', function(done) {
+      request(app.listen())
+        .get('/')
+        .expect('X-RateLimit-Remaining', 0)
+        .expect(429)
+        .end(done);
+    });
+  });
+
   describe('id', function (done) {
     it('should allow specifying a custom `id` function', function (done) {
       var app = koa();


### PR DESCRIPTION
It can be useful to centralize all application errors in a single error handler, but currently this is not possible because the ratelimit middleware automatically handles it. My suggestion, implemented in this PR, is to pass a new option (`throw: true`) to throw the error instead, allowing a custom error handler to process it.

I considered making this the default option, since `this.throw` makes it somewhat compatible with koa's built-in error handler. However, this is not the case because all headers are removed from the response, so `x-ratelimit-limit`, `x-ratelimit-remaining` and `x-ratelimit-reset` would be missing from the response.