### PR TITLE
Added custom error body text

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,9 @@ app.use(ratelimit({
     remaining: 'Rate-Limit-Remaining',
     reset: 'Rate-Limit-Reset',
     total: 'Rate-Limit-Total'
-  }
+  },
+  errorMsg: 'Rate limit exceeded, retry in ',
+  appendRetryTime: true
 }));
 
 // response middleware
@@ -64,6 +66,9 @@ console.log('listening on port 3000');
   - `remaining` remaining number of requests [`'X-RateLimit-Remaining'`]
   - `reset` reset timestamp [`'X-RateLimit-Reset'`]
   - `total` total number of requests [`'X-RateLimit-Limit'`]
+ - `throw` throw error if rate limit exceeded [false]
+ - `errorMsg` text in body of error response [`'Rate limit exceeded, retry in '`]
+ - `appendRetryTime` append retry time to error body text [true]
 
 ## Responses
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,9 @@ function ratelimit(opts) {
   opts.headers.remaining = opts.headers.remaining || 'X-RateLimit-Remaining';
   opts.headers.reset = opts.headers.reset || 'X-RateLimit-Reset';
   opts.headers.total = opts.headers.total || 'X-RateLimit-Limit';
+  opts.errorMsg = opts.errorMsg || 'Rate limit exceeded, retry in ';
+  opts.appendRetryTime = opts.appendRetryTime || true;
+  opts.throw = opts.throw || false;
 
   return function *(next){
     var id = opts.id ? opts.id(this) : this.ip;
@@ -69,7 +72,7 @@ function ratelimit(opts) {
     this.set('Retry-After', after);
 
     this.status = 429;
-    this.body = 'Rate limit exceeded, retry in ' + ms(delta, { long: true });
+    this.body = opts.errorMsg + (opts.appendRetryTime ? ms(delta, { long: true }) : '');
 
     if (opts.throw) {
       this.throw(this.status, this.body, { headers: headers });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "koa-ratelimit",
   "description": "Rate limiter middleware for koa",
   "repository": "koajs/ratelimit",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "keywords": [
     "koa",
     "middleware",

--- a/test/ratelimit.js
+++ b/test/ratelimit.js
@@ -193,6 +193,27 @@ describe('ratelimit middleware', function() {
     });
   });
 
+  describe('errorMsg', function (done) {
+    it('should allow using a custom error body message using the `errorMsg` value', function (done) {
+      var app = koa();
+
+      app.use(ratelimit({
+        db: db,
+        max: 1,
+        errorMsg: 'Exceeded limit, retry in '
+      }));
+
+      request(app.listen())
+        .get('/')
+        .expect(429)
+        .expect(function(res) {
+          res.text.should.startWith('Exceeded limit, retry in');
+          res.text.should.not.startWith('Rate limit exceeded, retry in');
+        })
+        .end(done);
+    });
+  });
+  
   describe('custom headers', function() {
     it('should allow specifying a custom header names', function(done) {
       var app = koa();


### PR DESCRIPTION
I made this change to allow for a custom error message in the body of the "429" response - reason being that my Koa application uses a scheme to label the error messages so they can be consumed by an automated client a bit easier.

Let me know what you think and thanks for this great middleware!