### PR TITLE
Update signature to use async/await for koa@2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
-  - "6"
+  - "7.6"
 services:
   - redis-server

--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@
 [node-image]: https://img.shields.io/badge/node.js-%3E=_0.11-red.svg?style=flat-square
 [node-url]: http://nodejs.org/download/
 
- Rate limiter middleware for koa.
+Rate limiter middleware for koa.
 
 ## Installation
 
@@ -23,32 +23,30 @@ $ npm install koa-ratelimit
 ## Example
 
 ```js
-var ratelimit = require('koa-ratelimit');
-var redis = require('redis');
-var koa = require('koa');
-var app = koa();
+const Koa = require('koa');
+const ratelimit = require('koa-ratelimit');
+const redis = require('ioredis');
+const app = new Koa();
 
 // apply rate limit
 
 app.use(ratelimit({
-  db: redis.createClient(),
+  db: new Redis(),
   duration: 60000,
-  max: 100,
-  id: function (context) {
-    return context.ip;
-  },
+  errorMessage: 'Sometimes You Just Have to Slow Down.',
+  id: (ctx) => ctx.ip,
   headers: {
     remaining: 'Rate-Limit-Remaining',
     reset: 'Rate-Limit-Reset',
     total: 'Rate-Limit-Total'
   },
-  errorMessage: 'Sometimes You Just Have to Slow Down.'
+  max: 100
 }));
 
 // response middleware
 
-app.use(function *(){
-  this.body = 'Stuff!';
+app.use(async (ctx) => {
+  ctx.body = 'Stuff!';
 });
 
 app.listen(3000);
@@ -58,18 +56,18 @@ console.log('listening on port 3000');
 ## Options
 
  - `db` redis connection instance
- - `max` max requests within `duration` [2500]
  - `duration` of limit in milliseconds [3600000]
+ - `errorMessage` custom error message
  - `id` id to compare requests [ip]
  - `headers` custom header names
+ - `max` max requests within `duration` [2500]
   - `remaining` remaining number of requests [`'X-RateLimit-Remaining'`]
   - `reset` reset timestamp [`'X-RateLimit-Reset'`]
   - `total` total number of requests [`'X-RateLimit-Limit'`]
- - `errorMessage` custom error message
 
 ## Responses
 
-  Example 200 with header fields:
+Example 200 with header fields:
 
 ```
 HTTP/1.1 200 OK
@@ -85,7 +83,7 @@ Connection: keep-alive
 Stuff!
 ```
 
-  Example 429 response:
+Example 429 response:
 
 ```
 HTTP/1.1 429 Too Many Requests
@@ -104,4 +102,4 @@ Rate limit exceeded, retry in 8 seconds
 
 ## License
 
-  MIT
+MIT

--- a/example.js
+++ b/example.js
@@ -1,21 +1,21 @@
 
+var Koa = require('koa');
 var ratelimit = require('./');
-var redis = require('redis');
-var koa = require('koa');
-var app = koa();
+var redis = require('ioredis');
+var app = new Koa();
 
 // apply rate limit
 
 app.use(ratelimit({
-  db: redis.createClient(),
+  db: new Redis(),
   duration: 60000,
   max: 100
 }));
 
 // response middleware
 
-app.use(function *(){
-  this.body = 'Stuff!';
+app.use(async function(ctx) {
+  ctx.body = 'Stuff!';
 });
 
 app.listen(4000);

--- a/package.json
+++ b/package.json
@@ -16,21 +16,20 @@
   "dependencies": {
     "debug": "^2.2.0",
     "ms": "^0.7.1",
-    "ratelimiter": "^2.1.2",
-    "thenify": "^3.2.0"
+    "ratelimiter": "^2.1.2"
   },
   "devDependencies": {
-    "koa": "^1.2.0",
-    "mocha": "^2.4.5",
-    "redis": "^2.6.0-1",
-    "should": "^8.3.0",
-    "supertest": "^1.2.0"
+    "koa": "^2.0.1",
+    "mocha": "^3.2.0",
+    "ioredis": "^3.0.0-0",
+    "should": "^11.2.0",
+    "supertest": "^3.0.0"
   },
   "scripts": {
     "test": "NODE_ENV=test mocha --reporter spec"
   },
   "engines": {
-    "node": ">= 0.11.13"
+    "node": ">=7"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
As stated by @dead-horse in https://github.com/koajs/ratelimit/pull/21#issuecomment-227956911, rewriting with async/await in mind for `koa@2`.