### PR TITLE
add opts.disableHeader support and fix test error for custom error message

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,8 @@ app.use(ratelimit({
     reset: 'Rate-Limit-Reset',
     total: 'Rate-Limit-Total'
   },
-  max: 100
+  max: 100,
+  disableHeader: false,
 }));
 
 // response middleware
@@ -61,6 +62,7 @@ console.log('listening on port 3000');
  - `id` id to compare requests [ip]
  - `headers` custom header names
  - `max` max requests within `duration` [2500]
+ - `disableHeader` set whether send the `remaining, reset, total` headers [false]
   - `remaining` remaining number of requests [`'X-RateLimit-Remaining'`]
   - `reset` reset timestamp [`'X-RateLimit-Reset'`]
   - `total` total number of requests [`'X-RateLimit-Limit'`]

--- a/index.js
+++ b/index.js
@@ -51,14 +51,19 @@ function ratelimit(opts = {}) {
     // check if current call is legit
     const calls = limit.remaining > 0 ? limit.remaining - 1 : 0;
 
-    // header fields
-    const headers = {
-      [remaining]: calls,
-      [reset]: limit.reset,
-      [total]: limit.total
-    };
+    // check if header disabled
+    const disableHeader = opts.disableHeader || false;
 
-    ctx.set(headers);
+    if (!disableHeader) {
+      // header fields
+      const headers = {
+        [remaining]: calls,
+        [reset]: limit.reset,
+        [total]: limit.total
+      };
+
+      ctx.set(headers);
+    }
 
     debug('remaining %s/%s %s', remaining, limit.total, id);
     if (limit.remaining) return await next();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "koa-ratelimit",
   "description": "Rate limiter middleware for koa",
   "repository": "koajs/ratelimit",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "keywords": [
     "koa",
     "middleware",

--- a/test/ratelimit.js
+++ b/test/ratelimit.js
@@ -228,6 +228,31 @@ describe('ratelimit middleware', () => {
         .expect((res) => res.text.should.match(/Rate limit exceeded, retry in \d+ minutes\./));
     });
   });
+
+  describe('disable headers', () => {
+    it('should disable headers when set opts.disableHeader', async () => {
+      const app = new Koa();
+
+      app.use(ratelimit({
+        db,
+        headers: {
+          remaining: 'Rate-Limit-Remaining',
+          reset: 'Rate-Limit-Reset',
+          total: 'Rate-Limit-Total'
+        },
+        disableHeader: true,
+        max: 1
+      }));
+
+      await request(app.listen())
+        .get('/')
+        .set('foo', 'bar')
+        .expect((res) => {
+          res.headers.should.not.have.keys('rate-limit-remaining', 'rate-limit-reset', 'rate-limit-total');
+          res.headers.should.not.have.keys('x-ratelimit-limit', 'x-ratelimit-remaining', 'x-ratelimit-reset');
+        });
+    });
+  });
 });
 
 async function sleep(ms) {

--- a/test/ratelimit.js
+++ b/test/ratelimit.js
@@ -225,7 +225,7 @@ describe('ratelimit middleware', () => {
         .get('/')
         .set('foo', 'bar')
         .expect(429)
-        .expect((res) => res.text.should.match(/Rate limit exceeded, retry in \d+ seconds\./));
+        .expect((res) => res.text.should.match(/Rate limit exceeded, retry in \d+ minutes\./));
     });
   });
 });


### PR DESCRIPTION
Set `opts.disableHeader = true` to stop sending response headers.
Ref #33 