### PR TITLE
Throw correct error when rate limit exceeded

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,9 +54,10 @@ function ratelimit(opts = {}) {
     // check if header disabled
     const disableHeader = opts.disableHeader || false;
 
+    let headers;
     if (!disableHeader) {
       // header fields
-      const headers = {
+      headers = {
         [remaining]: calls,
         [reset]: limit.reset,
         [total]: limit.total
@@ -76,7 +77,7 @@ function ratelimit(opts = {}) {
     ctx.body = opts.errorMessage || `Rate limit exceeded, retry in ${ms(delta, { long: true })}.`;
 
     if (opts.throw) {
-      ctx.throw(ctx.status, ctx.body, { headers: headers });
+      ctx.throw(ctx.status, ctx.body, { headers });
     }
   }
 }

--- a/test/ratelimit.js
+++ b/test/ratelimit.js
@@ -97,6 +97,7 @@ describe('ratelimit middleware', () => {
         .get('/')
         .expect('X-Custom', 'foobar')
         .expect('X-RateLimit-Remaining', '0')
+        .expect((res) => res.error.text.should.match(/^Rate limit exceeded, retry in.*/))
         .expect(429)
     });
   });


### PR DESCRIPTION
PR #34 accidentally changed behavior in the rate-limiting case by
moving the `headers` variable to a local scope, causing the `ctx.throw`
statement to throw an uncaught error. Fix that, and add a test line to
ensure we're throwing the expected error going forward.