### PR TITLE
feat: add whitelist and blacklist opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,8 +41,8 @@ function ratelimit(opts = {}) {
 
   return async function ratelimit(ctx, next) {
     const id = opts.id ? opts.id(ctx) : ctx.ip;
-    const whitelisted = typeof opts.whitelist === 'function' ? opts.whitelist(ctx) : false;
-    const blacklisted = typeof opts.blacklist === 'function' ? opts.blacklist(ctx) : false;
+    const whitelisted = typeof opts.whitelist === 'function' ? await opts.whitelist(ctx) : false;
+    const blacklisted = typeof opts.blacklist === 'function' ? await opts.blacklist(ctx) : false;
 
     if (true === blacklisted) {
       ctx.throw(403, 'Forbidden')

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = ratelimit;
  *  - `reset` reset timestamp ['X-RateLimit-Reset']
  *  - `total` total number of requests ['X-RateLimit-Limit']
  * - `whitelist` whitelist function [false]
+ * - `blacklist` blacklist function [false]
  *
  * @param {Object} opts
  * @return {Function}
@@ -41,6 +42,11 @@ function ratelimit(opts = {}) {
   return async function ratelimit(ctx, next) {
     const id = opts.id ? opts.id(ctx) : ctx.ip;
     const whitelisted = typeof opts.whitelist === 'function' ? opts.whitelist(ctx) : false;
+    const blacklisted = typeof opts.blacklist === 'function' ? opts.blacklist(ctx) : false;
+
+    if (blacklisted) {
+      ctx.throw(403, 'Forbidden')
+    }
 
     if (false === id || true === whitelisted) return await next();
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = ratelimit;
  *  - `remaining` remaining number of requests ['X-RateLimit-Remaining']
  *  - `reset` reset timestamp ['X-RateLimit-Reset']
  *  - `total` total number of requests ['X-RateLimit-Limit']
+ * - `whitelist` whitelist function [false]
  *
  * @param {Object} opts
  * @return {Function}
@@ -39,8 +40,9 @@ function ratelimit(opts = {}) {
 
   return async function ratelimit(ctx, next) {
     const id = opts.id ? opts.id(ctx) : ctx.ip;
+    const whitelisted = typeof opts.whitelist === 'function' ? opts.whitelist(ctx) : false;
 
-    if (false === id) return await next();
+    if (false === id || true === whitelisted) return await next();
 
     // initialize limiter
     const limiter = new Limiter(Object.assign({}, opts, { id }));

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function ratelimit(opts = {}) {
     const whitelisted = typeof opts.whitelist === 'function' ? opts.whitelist(ctx) : false;
     const blacklisted = typeof opts.blacklist === 'function' ? opts.blacklist(ctx) : false;
 
-    if (blacklisted) {
+    if (true === blacklisted) {
       ctx.throw(403, 'Forbidden')
     }
 

--- a/test/ratelimit.js
+++ b/test/ratelimit.js
@@ -157,6 +157,55 @@ describe('ratelimit middleware', () => {
     });
   });
 
+  describe('whitelist', () => {
+    const duration = 1000;
+    let guard;
+    let app;
+
+    const hitOnce = () => guard.should.equal(1);
+
+    beforeEach(async () => {
+      app = new Koa();
+
+      app.use(ratelimit({
+        db,
+        whitelist: (ctx) => ctx.request.header.foo === 'whitelistme',
+        max: 1
+      }));
+      app.use(async (ctx) => {
+        guard++;
+        ctx.body = 'foo';
+      });
+
+      guard = 0;
+
+      await sleep(duration);
+      await request(app.listen())
+        .get('/')
+        .expect(200)
+        .expect(hitOnce)
+    });
+
+    it('should not limit if satisfy whitelist function', async () => {
+      await request(app.listen())
+        .get('/')
+        .set('foo', 'whitelistme')
+        .expect(200)
+
+      await request(app.listen())
+        .get('/')
+        .set('foo', 'whitelistme')
+        .expect(200)
+    });
+
+    it('should limit as usual if not whitelist return false', async () => {
+      await request(app.listen())
+        .get('/')
+        .set('foo', 'imnotwhitelisted')
+        .expect(429)
+    });
+  })
+
   describe('custom headers', () => {
     it('should allow specifying custom header names', async () => {
       const app = new Koa();

--- a/test/ratelimit.js
+++ b/test/ratelimit.js
@@ -206,6 +206,38 @@ describe('ratelimit middleware', () => {
     });
   })
 
+  describe('blacklist', () => {
+    let app;
+
+    beforeEach(async () => {
+      app = new Koa();
+
+      app.use(ratelimit({
+        db,
+        blacklist: (ctx) => ctx.request.header.foo === 'blacklisted',
+        max: 1
+      }));
+      app.use(async (ctx) => {
+        ctx.body = 'foo';
+      });
+
+    });
+
+    it('should throw 403 if blacklisted', async () => {
+      await request(app.listen())
+        .get('/')
+        .set('foo', 'blacklisted')
+        .expect(403)
+    });
+
+    it('should return 200 when not blacklisted', async () => {
+      await request(app.listen())
+        .get('/')
+        .set('foo', 'imnotblacklisted')
+        .expect(200)
+    });
+  })
+
   describe('custom headers', () => {
     it('should allow specifying custom header names', async () => {
       const app = new Koa();


### PR DESCRIPTION
add `whitelist`and `blacklist` option.

Fixes: #1 and #2 

```
app = new Koa();

app.use(ratelimit({
    db,
    whitelist: (ctx) => ctx.request.header.foo === 'whitelistme',
    max: 1
}));
```

or 
```
app.use(ratelimit({
    db,
    blacklist: (ctx) => ctx.request.header.foo === 'blacklisted',
    max: 1
}));
```