### PR TITLE
Set 'Retry-After' header when throwing error

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ module.exports = function ratelimit (opts = {}) {
     ctx.body = opts.errorMessage || `Rate limit exceeded, retry in ${ms(delta, { long: true })}.`
 
     if (opts.throw) {
+      headers['Retry-After'] = after
       ctx.throw(ctx.status, ctx.body, { headers })
     }
   }

--- a/test/redis.spec.js
+++ b/test/redis.spec.js
@@ -61,18 +61,20 @@ describe('ratelimit middleware with redis driver', () => {
   describe('limit with throw', () => {
     let guard
     let app
+    let errorWasThrown
 
     const hitOnce = () => guard.should.equal(1)
 
     beforeEach(async () => {
       app = new Koa()
+      errorWasThrown = false
 
       app.use(async (ctx, next) => {
         try {
           await next()
         } catch (e) {
-          ctx.body = e.message
-          ctx.set(Object.assign({ 'X-Custom': 'foobar' }, e.headers))
+          errorWasThrown = true
+          throw e
         }
       })
 
@@ -102,10 +104,13 @@ describe('ratelimit middleware with redis driver', () => {
     it('responds with 429 when rate limit is exceeded', async () => {
       await request(app.listen())
         .get('/')
-        .expect('X-Custom', 'foobar')
         .expect('X-RateLimit-Remaining', '0')
+        .expect('Retry-After', '0')
         .expect((res) => res.error.text.should.match(/^Rate limit exceeded, retry in.*/))
         .expect(429)
+        .then(() => {
+          errorWasThrown.should.equal(true)
+        })
     })
   })
 


### PR DESCRIPTION
This change sets the 'Retry-After' response header when throwing the 429 error (i.e. the `throw` option is set to `true`). Previously this was not the case because Koa's [default error handler](https://github.com/koajs/koa/blob/2.13.1/lib/context.js#L138) unsets all response headers before setting those specified in the error object.

I had to change the error handling in the tests because catching and handling the error bypassed Koa's error handler.

Please let me know if you have questions or suggestions